### PR TITLE
Refactored MOTD to use the appropriate event.

### DIFF
--- a/Sadie.Networking.Events/EventHandlerIds.cs
+++ b/Sadie.Networking.Events/EventHandlerIds.cs
@@ -12,7 +12,7 @@ public class EventHandlerIds
     public const short PlayerBalance = 273;
     public const short PlayerSubscription = 3166;
     public const short NavigatorData = 2110;
-    public const short PlayerFriendsList = 1523;
+    public const short MOTD = 1523;
     public const short PlayerMessengerInit = 2781;
     public const short PlayerPing = 295;
     public const short PlayerPong = 2596;

--- a/Sadie.Networking.Events/Handlers/Notifications/MOTDEventHandler.cs
+++ b/Sadie.Networking.Events/Handlers/Notifications/MOTDEventHandler.cs
@@ -1,0 +1,26 @@
+﻿using Sadie.Database.Models;
+using Sadie.Networking.Client;
+using Sadie.Networking.Packets;
+using Sadie.Shared;
+using Sadie.Shared.Unsorted;
+
+namespace Sadie.Networking.Events.Handlers.Notifications;
+
+public class MOTDEventHandler(ServerSettings serverSettings) : INetworkPacketEventHandler
+{
+    public int Id => EventHandlerIds.MOTD;
+
+    public async Task HandleAsync(INetworkClient client, INetworkPacketReader reader)
+    {
+        if (string.IsNullOrEmpty(serverSettings.PlayerWelcomeMessage))
+        {
+            return;
+        }
+
+        var formattedMessage = serverSettings.PlayerWelcomeMessage
+            .Replace("[username]", client.Player.Username)
+            .Replace("[version]", GlobalState.Version.ToString());
+
+        await client.Player.NetworkObject.WriteToStreamAsync(new PlayerAlertWriter(formattedMessage).GetAllBytes());
+    }
+}


### PR DESCRIPTION
MOTD shouldn't be sent via the SecureLogin event. We should be using the appropriate event that gets called after the player has been authenticated.

Note: This will need to be checked with Nitro (I don't have it setup), they currently have the header id listed incorrectly and I'm not sure if they even have the event coded.